### PR TITLE
Fix history for non-numeric sensors

### DIFF
--- a/custom_components/volkswagen_we_connect_id/sensor.py
+++ b/custom_components/volkswagen_we_connect_id/sensor.py
@@ -225,8 +225,9 @@ class VolkswagenIDSensor(VolkswagenIDBaseEntity, SensorEntity):
         self._coordinator = coordinator
         self._attr_name = f"{self.data.nickname} {sensor.name}"
         self._attr_unique_id = f"{self.data.vin}-{sensor.key}"
-        self._attr_native_unit_of_measurement = sensor.native_unit_of_measurement
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        if sensor.native_unit_of_measurement:
+            self._attr_native_unit_of_measurement = sensor.native_unit_of_measurement
+            self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self) -> StateType:


### PR DESCRIPTION
Non numeric sensors (such as charge type and others) are being created with state_class: MEASUREMENT (and a unit of measurement), causing its history to appear as an empty line graph.